### PR TITLE
add MCP server badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,9 @@
 [![MseeP.ai Security Assessment Badge](https://mseep.net/pr/dulbrich-familysearch-mcp-badge.png)](https://mseep.ai/app/dulbrich-familysearch-mcp)
 
+<a href="https://glama.ai/mcp/servers/@dulbrich/familysearch-mcp">
+  <img width="380" height="200" src="https://glama.ai/mcp/servers/@dulbrich/familysearch-mcp/badge" alt="FamilySearch Server MCP server" />
+</a>
+
 # FamilySearch MCP Server
 
 This is a Model Context Protocol (MCP) server for FamilySearch APIs. It allows AI tools like Claude or Cursor to interact with FamilySearch's family history data directly.
@@ -113,4 +117,4 @@ Your FamilySearch credentials are stored locally on your machine in `~/.familyse
 
 ## License
 
-ISC 
+ISC


### PR DESCRIPTION
This PR adds a badge for the [FamilySearch MCP Server](https://glama.ai/mcp/servers/@dulbrich/familysearch-mcp) server listing in Glama MCP server directory.

<a href="https://glama.ai/mcp/servers/@dulbrich/familysearch-mcp">
  <img width="380" height="200" src="https://glama.ai/mcp/servers/@dulbrich/familysearch-mcp/badge" alt="FamilySearch Server MCP server" />
</a>

Glama performs regular codebase and documentation checks to:

* Confirm that the MCP server is working as expected
* Confirm that there are no obvious security issues with dependencies of the server
* Extract server characteristics such as tools, resources, prompts, and required parameters.

This badge helps your users to quickly assess that the MCP server is safe, server capabilities, and instructions for installing the server.